### PR TITLE
301 redirects: legacy blog URLs to tech.teksoma.com insights

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,18 @@
+# cmpsoares.com → tech.teksoma.com insights migration (301)
+
+/blog/2022-01-25_why-you-should-have-the-habit-to-sign-all-your-git-commits/*  https://tech.teksoma.com/insights/sign-git-commits  301!
+/blog/2022-01-25-why-you-should-have-the-habit-to-sign-all-your-git-commits/*  https://tech.teksoma.com/insights/sign-git-commits  301!
+
+/blog/2023-06-18_deciphering-techs-unsung-heroes-a-laymans-guide-to-devops-sre-infrastructure-cloud-devsecops-and-sysadmin-roles/*  https://tech.teksoma.com/insights/deciphering-tech-unsung-heroes  301!
+
+/blog/2023-06-19_unleashing-the-superheroes-of-sre-unlocking-the-power-of-site-reliability-engineering/*  https://tech.teksoma.com/insights/unleashing-sre-superheroes  301!
+
+/blog/2023-07-20_aristotles-legacy-unfolding-the-logic-of-language-learning-models-and-generative-ai/*  https://tech.teksoma.com/insights/aristotles-legacy-llm-generative-ai  301!
+
+/blog/2023-08-21_terraform-future-support-keeping-it-open/*  https://tech.teksoma.com/insights/terraform-future-support-keeping-it-open  301!
+
+/blog/2023-08-22_the-ultimate-guide-to-github-repository-centralizing-your-github-management/*  https://tech.teksoma.com/insights/github-org-centralization-guide  301!
+
+/blog/2024-11-14_rca-showdown-sre-vs-itil-itsm/*  https://tech.teksoma.com/insights/rca-showdown-sre-vs-itil-itsm  301!
+
+/blog/*  https://tech.teksoma.com/insights  301!


### PR DESCRIPTION
## Summary
- Add Netlify `_redirects` mapping each legacy `/blog/*` path to the matching `tech.teksoma.com/insights/*` URL
- Catch-all `/blog/*` → `/insights` for any unmapped posts

## Test plan
- [ ] Deploy preview and verify `/blog/2022-01-25_why-you-should-have-the-habit-to-sign-all-your-git-commits/` → insights/sign-git-commits
- [ ] Verify catch-all `/blog/unknown/` → tech.teksoma.com/insights
- [ ] Confirm homepage redirect to tech.teksoma.com still works


Made with [Cursor](https://cursor.com)